### PR TITLE
Move subscription form with URL parameter

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -109,11 +109,16 @@
     <script>
         window.addEventListener("load", function () {
             const form = document.getElementById("form-container");
-            const contactWrapper =
-                document.getElementById("contact-wrapper");
-            const thankYouMessageTemplate = document.getElementById(
-                "thank-you-message-template"
-            );
+            const contactWrapper = document.getElementById("contact-wrapper");
+            const formUpwards = document.getElementById("form-upwards");
+            const thankYouMessageTemplate = document.getElementById("thank-you-message-template");
+
+            // if parameter subscribe is set, move the contactWrapper within the formUpwards
+            if (window.location.search.includes("subscribe")) {
+                document.querySelector('header').style.display = 'none';
+                formUpwards.appendChild(contactWrapper);
+            }
+
             form.addEventListener("submit", function (e) {
                 e.preventDefault();
                 const data = new FormData(form);
@@ -172,6 +177,8 @@
                 alt="deploio logo"
         />
         <h1>Der Turbo für dein App Hosting</h1>
+        <div id="form-upwards"></div>
+
         <a href="https://www.swissmadesoftware.org/home.html">
             <img
                     class="swiss-logo"


### PR DESCRIPTION
This PR is born from the need of bringing up the subscription form.
The idea is that during the conference people can subscribe, and they'll most probably be on their phone.
They already got an introduction about the platform from us, so we can present the subscription form right away instead of making them scroll until the bottom.

At the conference there will be a poster pointing already to https://deplo.io?subscribe=true

This is the result on iPhone 14. Also buttons on the top have been removed since people will simply subscribe for Beta.
![CleanShot 2023-11-23 at 21 10 41@2x](https://github.com/ninech/deploio-site/assets/1319150/6b68d7f9-e48e-4c8e-9af5-585b57034467)
