### PR TITLE
feat: remove php stub

### DIFF
--- a/public/fake.php
+++ b/public/fake.php
@@ -1,3 +1,0 @@
-<?php
-header('Location: index.html');
-?>


### PR DESCRIPTION
this was a workaround before deplo.io introduced static site support.