### PR TITLE
Update link translations

### DIFF
--- a/public/en.html
+++ b/public/en.html
@@ -188,7 +188,7 @@
             <h1>Turbocharge your App-Hosting</h1>
             <div id="form-upwards"></div>
 
-            <a href="https://www.swissmadesoftware.org/home.html">
+            <a href="https://www.swissmadesoftware.org/en/home.html">
                 <img
                         class="swiss-logo"
                         src="assets/images/swiss.png"
@@ -291,7 +291,7 @@
                 </ul>
                 <div class="discover-more">
                     <a
-                            href="https://docs.nine.ch/en/docs/category/deploio"
+                            href="https://docs.nine.ch/docs/category/deploio"
                             class="btn btn-secondary btn-lg discover-more-btn"
                     >Learn More</a>
                 </div>
@@ -996,7 +996,7 @@
                 <h3>Service Provided By</h3>
                 <ul>
                     <li>
-                        <a href="https://www.nine.ch">
+                        <a href="https://www.nine.ch/en">
                             <img
                                     src="assets/images/nine-Logo.png"
                                     alt="nine"
@@ -1025,7 +1025,7 @@
             </div>
             <div class="column">
                 <a
-                        href="https://docs.nine.ch/en/docs/legal-documents/general-terms-and-conditions"
+                        href="https://docs.nine.ch/docs/legal-documents/general-terms-and-conditions"
                 >Terms & Conditions</a
                 >
                 <a href="https://www.nine.ch/en/privacy-policy"

--- a/public/en.html
+++ b/public/en.html
@@ -162,7 +162,7 @@
         >
         <div>
             <a
-                    href="https://cockpit.nine.ch/de/session/new?origin=%2F"
+                    href="https://cockpit.nine.ch/en/session/new?origin=%2F"
                     target="_blank"
                     class="btn btn-sm bg-gradient"
             >Sign In</a
@@ -291,7 +291,7 @@
                 </ul>
                 <div class="discover-more">
                     <a
-                            href="https://docs.nine.ch/de/docs/category/deploio"
+                            href="https://docs.nine.ch/en/docs/category/deploio"
                             class="btn btn-secondary btn-lg discover-more-btn"
                     >Learn More</a>
                 </div>
@@ -1025,10 +1025,10 @@
             </div>
             <div class="column">
                 <a
-                        href="https://docs.nine.ch/de/docs/legal-documents/general-terms-and-conditions"
+                        href="https://docs.nine.ch/en/docs/legal-documents/general-terms-and-conditions"
                 >Terms & Conditions</a
                 >
-                <a href="https://www.nine.ch/de/privacy-policy"
+                <a href="https://www.nine.ch/en/privacy-policy"
                 >Privacy policy</a
                 >
             </div>

--- a/public/index.html
+++ b/public/index.html
@@ -890,7 +890,7 @@
                 <h3>Support</h3>
                 <ul>
                     <li>
-                        <a href="https://status.nine.ch/">Status</a>
+                        <a href="https://status.nine.ch/de">Status</a>
                     </li>
                     <li>
                         <a href="https://docs.nine.ch/de/docs/category/deploio"
@@ -1013,7 +1013,7 @@
                         </a>
                     </li>
                     <li>
-                        <a href="https://www.renuo.ch">
+                        <a href="https://www.renuo.ch/de">
                             <img
                                     src="assets/images/Renuo-Logo.png"
                                     alt="renuo"


### PR DESCRIPTION
As the title already says, this PR aims at improving the links on the landing page to adapt to the user language preferences. This means that some links were pointing to the english version a page in the german landing page and some links were pointing to the german version in the english landing page. This issue has been addressed by updating the links accordingly.