### PR TITLE
Fix clipboard permission

### DIFF
--- a/public/en.html
+++ b/public/en.html
@@ -339,7 +339,7 @@
         </section>
 
         <section>
-          <iframe id="calculator-iframe" class="pricing-calculator-wrapper" src="https://pricing-calculator-deploio.e1b591d.deploio.app"></iframe>
+          <iframe id="calculator-iframe" allow="clipboard-read; clipboard-write" class="pricing-calculator-wrapper" src="https://pricing-calculator-deploio.e1b591d.deploio.app"></iframe>
         </section>
 
         <section class="section-comparison reduced-width">

--- a/public/index.html
+++ b/public/index.html
@@ -345,7 +345,7 @@
         </section>
 
         <section>
-          <iframe id="calculator-iframe" class="pricing-calculator-wrapper" src="https://pricing-calculator-deploio.e1b591d.deploio.app"></iframe>
+          <iframe id="calculator-iframe" allow="clipboard-read; clipboard-write" class="pricing-calculator-wrapper" src="https://pricing-calculator-deploio.e1b591d.deploio.app"></iframe>
         </section>
 
         <section class="section-comparison reduced-width">


### PR DESCRIPTION
It looks like chrome automatically blocks the Clipboard API call of the pricing calculator because it is in an unsafe context as specified by the mozilla docs:
https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts