### PR TITLE
Implement iframe resizing

### DIFF
--- a/public/en.html
+++ b/public/en.html
@@ -342,6 +342,17 @@
           <iframe id="calculator-iframe" allow="clipboard-read; clipboard-write" class="pricing-calculator-wrapper" src="https://pricing-calculator-deploio.e1b591d.deploio.app"></iframe>
         </section>
 
+        <script>
+          const iframe = document.querySelector("#calculator-iframe");
+
+          window.addEventListener('message', function(e) {
+            const message = e.data;
+
+            iframe.style.height = message.height + 'px';
+            iframe.style.width = message.width + 'px';
+          } , false);
+        </script>
+
         <section class="section-comparison reduced-width">
             <h2 class="seo">Comparison table</h2>
             <div>

--- a/public/index.html
+++ b/public/index.html
@@ -348,6 +348,18 @@
           <iframe id="calculator-iframe" allow="clipboard-read; clipboard-write" class="pricing-calculator-wrapper" src="https://pricing-calculator-deploio.e1b591d.deploio.app"></iframe>
         </section>
 
+        <script>
+          const iframe = document.querySelector("#calculator-iframe");
+
+          window.addEventListener('message', function(e) {
+            const message = e.data;
+
+            iframe.style.height = message.height + 'px';
+            iframe.style.width = message.width + 'px';
+          } , false);
+        </script>
+
+
         <section class="section-comparison reduced-width">
             <h2 class="seo">Comparison table</h2>
             <div>

--- a/public/index.html
+++ b/public/index.html
@@ -359,7 +359,6 @@
           } , false);
         </script>
 
-
         <section class="section-comparison reduced-width">
             <h2 class="seo">Comparison table</h2>
             <div>


### PR DESCRIPTION
Because of SecureContexts and the way Iframes work, you cannot access the contentView height inside a CrossOrigin Iframe element. The only way is by using postMessages as described in:
https://usefulangle.com/post/65/javascript-automatically-resize-iframe

## Related PRs

This is the message implementation in the pricing calculator:
https://github.com/ninech/pricing-calculator-deploio/pull/2

## Testing

This code has been tested to work locally by running the website with http-server and the pricing calculator using vite. Without the message post, the Iframe height remained unchanged regardless of how many sections unfolded.