### PR TITLE
Remove sign up link in header

### DIFF
--- a/public/en.html
+++ b/public/en.html
@@ -182,9 +182,6 @@
                     class="btn btn-sm bg-gradient"
             >Sign In</a
             >
-            <a href="#contact-wrapper" class="btn btn-sm bg-gradient"
-            >Sign Up</a
-            >
             <div class="language-toggle">
                 <a href="index.html">de</a>
                 <a class="active" href="#">en</a>

--- a/public/index.html
+++ b/public/index.html
@@ -182,9 +182,6 @@
                     class="btn btn-sm bg-gradient"
             >Login</a
             >
-            <a href="#contact-wrapper" class="btn btn-sm bg-gradient"
-            >Registrieren</a
-            >
             <div class="language-toggle">
                 <a class="active" href="#">de</a>
                 <a href="en.html">en</a>


### PR DESCRIPTION
![CleanShot 2024-08-29 at 09 55 03@2x](https://github.com/user-attachments/assets/22374c3d-b678-4c80-9de5-c2f6bc51f0aa)

having two almost identical buttons on the right was pretty confusing for me. `Start now` points to the same anchor, so I removed the sign up link on the right